### PR TITLE
Remove timeout from http-server workers for long-running scripts

### DIFF
--- a/lib/worker-servers.js
+++ b/lib/worker-servers.js
@@ -171,6 +171,7 @@ if (!cluster.isMaster) {
       })
     })
 
+    server.timeout = 0
     server.listen(port, host)
   }
 


### PR DESCRIPTION
By default, Node sockets will timeout at two minutes (https://nodejs.org/dist/latest-v10.x/docs/api/http.html#http_server_timeout).  If you are using the 'http-server' strategy and you have scripts that take longer than two minutes to complete, the following error occurs after two minutes and the script does not complete:

```
Error: socket hang up
    at createHangUpError (_http_client.js:331:15)
    at Socket.socketOnEnd (_http_client.js:423:23)
    at emitNone (events.js:111:20)
    at Socket.emit (events.js:208:7)
    at endReadableNT (_stream_readable.js:1064:12)
    at _combinedTickCallback (internal/process/next_tick.js:139:11)
    at process._tickCallback (internal/process/next_tick.js:181:9)
```

This pull request simply sets the timeout to 0, disabling the http socket timeout.  The timeout value passed into the ScriptManager is still respected, since we don't want the connection really left open forever.  The timer in manager-servers.js will return "Timeout error during executing script" and kill the process when this occurs.

This was tested locally using JsReport 2.2, where in the configuration for the scripts extension, my timeout was set to 1200000 and my strategy was set to 'http-server'.